### PR TITLE
Fix optional date in conceptType

### DIFF
--- a/src/python/loin/iso_23887.py
+++ b/src/python/loin/iso_23887.py
@@ -111,6 +111,12 @@ class ConceptType:
     class Meta:
         name = "conceptType"
 
+    date: XmlDateTime = field(
+        metadata={
+            "type": "Attribute",
+            "required": True,
+        }
+    )
     name: List[MultilingualTextType] = field(
         default_factory=list,
         metadata={
@@ -149,13 +155,6 @@ class ConceptType:
             "type": "Attribute",
             "required": True,
             "pattern": r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
-        }
-    )
-    date: Optional[XmlDateTime] = field(
-        default=None,
-        metadata={
-            "type": "Attribute",
-            "required": True,
         }
     )
 


### PR DESCRIPTION
The ISO 23387 xsd specifies the date of a conceptType to be required. The previous implementation included the date as optional. Move the date property up in the class definition, as properties without default value cannot be defined after properties with default values.