### PR TITLE
Auto create UUIDs

### DIFF
--- a/src/python/loin/en_17412_3.py
+++ b/src/python/loin/en_17412_3.py
@@ -5,6 +5,7 @@ from loin.iso_23887 import (
     DataTemplateType,
     ObjectType,
 )
+from loin.utils import new_uuid
 
 __NAMESPACE__ = "https://iso.org/2022/LOIN"
 
@@ -188,7 +189,7 @@ class SpecificationPerObjectType:
         }
     )
     uuid: Optional[str] = field(
-        default=None,
+        default_factory=new_uuid,
         metadata={
             "name": "UUID",
             "type": "Attribute",
@@ -224,7 +225,7 @@ class Specification:
         }
     )
     uuid: Optional[str] = field(
-        default=None,
+        default_factory=new_uuid,
         metadata={
             "name": "UUID",
             "type": "Attribute",

--- a/src/python/loin/iso_23887.py
+++ b/src/python/loin/iso_23887.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import List, Optional, Union
 from xsdata.models.datatype import XmlDateTime
 from loin.xml import LangValue
+from loin.utils import new_uuid
 
 __NAMESPACE__ = "http://tempuri.org/XMLSchema.xsd"
 
@@ -143,7 +144,7 @@ class ConceptType:
         }
     )
     node_id: Optional[str] = field(
-        default=None,
+        default_factory=new_uuid,
         metadata={
             "name": "nodeID",
             "type": "Attribute",

--- a/src/python/loin/iso_23887.py
+++ b/src/python/loin/iso_23887.py
@@ -143,7 +143,7 @@ class ConceptType:
             "type": "Attribute",
         }
     )
-    node_id: Optional[str] = field(
+    node_id: str = field(
         default_factory=new_uuid,
         metadata={
             "name": "nodeID",

--- a/src/python/loin/utils.py
+++ b/src/python/loin/utils.py
@@ -1,0 +1,5 @@
+import uuid
+
+
+def new_uuid():
+    return str(uuid.uuid4())


### PR DESCRIPTION
Those types that require an UUID to be set now initialize it using the default constructor and the Python `uuid` module.