### PR TITLE
Adjust test script

### DIFF
--- a/src/python/loin-xml-xsdata.py
+++ b/src/python/loin-xml-xsdata.py
@@ -1,79 +1,110 @@
-from loin.en_17412_3 import *
-from loin.iso_23887 import *
+from dataclasses import dataclass
+from typing import List
+from loin.en_17412_3 import (
+    LevelOfInformationNeed,
+    Specification,
+    SpecificationPerObjectType,
+    ObjectType,
+)
+from loin.iso_23887 import (
+    DataTemplateType,
+    DatatypeType,
+    DatatypeTypeName,
+    MultilingualTextType,
+    ScaleType,
+    PropertyType,
+    ReferenceType,
+    UnitType,
+    BaseType,
+)
 from xsdata.formats.dataclass.serializers import XmlSerializer
 from xsdata.formats.dataclass.serializers.config import SerializerConfig
+from xsdata.models.datatype import XmlDateTime
+
 
 # Define a container dataclass to hold objects of different types
 @dataclass
 class Container:
     Loin: List[LevelOfInformationNeed]
     Object: List[ObjectType]
-    Unit : List[UnitType]
-    Property : List[PropertyType]
+    Unit: List[UnitType]
+    Property: List[PropertyType]
+
 
 # Instantiate the objects of the generated classes
 my_loin = LevelOfInformationNeed()
 my_specification = Specification()
-my_loin.specification = my_specification
+my_loin.specification.append(my_specification)
 
 # Populate the objects with data
 my_specification.description = "LOIN for Bridge data at handover to client"
 my_specification.name = "Bridge_Handover_to_Client"
 
 specification_for_wingwalls = SpecificationPerObjectType()
-my_specification.specification_per_object_type = specification_for_wingwalls
+my_specification.specification_per_object_type.append(
+    specification_for_wingwalls)
 
-specification_for_wingwalls.alphanumerical_information = None
-specification_for_wingwalls.documentation = None
-specification_for_wingwalls.uuid = "10108f20-34b2-4996-aa7d-5ec9ba182234"
+# not required because default is empty list
+# specification_for_wingwalls.alphanumerical_information = None
+# specification_for_wingwalls.documentation = None
+# not required anymore, because the ConceptType default constructor aready creates one
+# specification_for_wingwalls.uuid = "10108f20-34b2-4996-aa7d-5ec9ba182234"
 
-
-my_object_type = ObjectType()
-specification_for_wingwalls.object_type = my_object_type
-my_object_type.node_id = "3b7802f6-b9a2-4062-ab23-69fa92c4984f"
-my_object_type.name = "Wing Wall"
+date = XmlDateTime(2024, 6, 14, 10, 17, 3)
+my_object_type = ObjectType(date=date)
+# my_object_type.node_id = "3b7802f6-b9a2-4062-ab23-69fa92c4984f"
+my_object_type.name.append(MultilingualTextType("Wing Wall", "en"))
+my_object_type.name.append(MultilingualTextType("Flügelmauer", "de"))
 my_object_type_ref = ReferenceType(node_id=my_object_type.node_id)
+# QUESTION: why does this not need to be a reference? See DataTemplateType
+specification_for_wingwalls.object_type = my_object_type
 
-string_type = DatatypeType()
-string_type.name = "REAL"
+real_type = DatatypeType()
+real_type.name = DatatypeTypeName.REAL
 
-centimeter_unit = UnitType()
-centimeter_unit.node_id = "ebdfe50c-474a-482e-9bd6-db93bcaac3d1"
-centimeter_unit.name = "Centimeter"
-centimeter_unit.definition ="Centimeter according to ISO 80000"
-centimeter_unit.scale = "LINEAR"
-centimeter_unit.base = "TEN"
+centimeter_unit = UnitType(date=date)
+# centimeter_unit.node_id = "ebdfe50c-474a-482e-9bd6-db93bcaac3d1"
+centimeter_unit.name.append(MultilingualTextType("Centimeter", "en"))
+centimeter_unit.symbol.append(MultilingualTextType("cm", "en"))
+centimeter_unit.definition.append(MultilingualTextType(
+    "Centimeter according to ISO 80000", "en"))
+centimeter_unit.scale = ScaleType.LINEAR
+centimeter_unit.base = BaseType.TEN
 centimeter_unit.coefficient = 100
 centimeter_unit.offset = 0
 centimeter_unit_ref = ReferenceType(node_id=centimeter_unit.node_id)
 
-width_property = PropertyType()
-width_property.node_id = "8ef0be47-929f-428a-9016-ec1e1f1f7616"
-width_property.name = "width"
-width_property.data_type = "REAL"
-width_property.unit = centimeter_unit_ref
-width_property_ref =ReferenceType(node_id=width_property.node_id)
+width_property = PropertyType(date=date)
+# width_property.node_id = "8ef0be47-929f-428a-9016-ec1e1f1f7616"
+width_property.name.append(MultilingualTextType("Width", "en"))
+width_property.data_type = real_type
+width_property.unit.append(centimeter_unit_ref)
+width_property_ref = ReferenceType(node_id=width_property.node_id)
 
-length_property = PropertyType()
-length_property.node_id = "c4a14d69-1ad7-4e66-bacc-7985e21493ba"
-length_property.name= "length"
-length_property.data_type = "REAL"
-length_property.unit = centimeter_unit_ref
-length_property_ref =ReferenceType(node_id=length_property.node_id)
+length_property = PropertyType(date=date)
+# length_property.node_id = "c4a14d69-1ad7-4e66-bacc-7985e21493ba"
+length_property.name.append(MultilingualTextType("Length", "en"))
+length_property.data_type = real_type
+length_property.unit.append(centimeter_unit_ref)
+length_property_ref = ReferenceType(node_id=length_property.node_id)
 
-my_data_template = DataTemplateType()
-specification_for_wingwalls.alphanumerical_information = [my_data_template]
-#my_data_template.object_value = my_object_type  # not allowed, must use ref
-my_data_template.object_value = my_object_type_ref
+my_data_template = DataTemplateType(date=date)
+# my_data_template.object_value = my_object_type  # not allowed, must use ref
+my_data_template.object_value.append(my_object_type_ref)
 my_data_template.property = [width_property_ref, length_property_ref]
+specification_for_wingwalls.alphanumerical_information.append(my_data_template)
 
 # Create a container object to hold objects of different types
-container = Container(Loin=[my_loin], Object=[my_object_type], Unit=[centimeter_unit], Property=[width_property, length_property])
+container = Container(Loin=[my_loin],
+                      Object=[my_object_type],  # PD: Fix for double definition of object could be to not pass it here, but use an empty list. Then the Object property of the Container would not be needed anymore.
+                      Unit=[centimeter_unit],
+                      Property=[width_property, length_property])
 
 
 # Create a SerializerConfig with custom settings
 serializer_config = SerializerConfig(
-    pretty_print=True,          # Enable pretty-printing (adds line breaks and indentation)
+    # Enable pretty-printing (adds line breaks and indentation)
+    pretty_print=True,
     pretty_print_indent="    "  # Indentation using 4 spaces (adjust as needed)
 )
 

--- a/src/python/output.xml
+++ b/src/python/output.xml
@@ -1,39 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Container>
     <Loin>
-        <Specification name="Bridge_Handover_to_Client">
+        <Specification UUID="3f54f2bf-efb0-4a24-bfa5-43da577d7969" name="Bridge_Handover_to_Client">
             <Description>LOIN for Bridge data at handover to client</Description>
-            <SpecificationPerObjectType UUID="10108f20-34b2-4996-aa7d-5ec9ba182234">
-                <ObjectType nodeID="3b7802f6-b9a2-4062-ab23-69fa92c4984f">
-                    <ns0:Name xmlns:ns0="http://tempuri.org/XMLSchema.xsd">Wing Wall</ns0:Name>
+            <SpecificationPerObjectType UUID="317aab53-1538-4e0d-a702-233c1be1282f">
+                <ObjectType nodeID="ca4c1d79-fccf-4d44-bce8-88db884eb8ee" date="2024-06-14T10:17:03">
+                    <ns0:Name xmlns:ns0="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Wing Wall</ns0:Name>
+                    <ns0:Name xmlns:ns0="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="de">Flügelmauer</ns0:Name>
                 </ObjectType>
-                <AlphanumericalInformation>
-                    <ns0:Object xmlns:ns0="http://tempuri.org/XMLSchema.xsd" nodeID="3b7802f6-b9a2-4062-ab23-69fa92c4984f"/>
-                    <ns0:Property xmlns:ns0="http://tempuri.org/XMLSchema.xsd" nodeID="8ef0be47-929f-428a-9016-ec1e1f1f7616"/>
-                    <ns0:Property xmlns:ns0="http://tempuri.org/XMLSchema.xsd" nodeID="c4a14d69-1ad7-4e66-bacc-7985e21493ba"/>
+                <AlphanumericalInformation nodeID="7687cb22-d98a-4d50-b2e8-0ec7f8ca6497" date="2024-06-14T10:17:03">
+                    <ns0:Object xmlns:ns0="http://tempuri.org/XMLSchema.xsd" nodeID="ca4c1d79-fccf-4d44-bce8-88db884eb8ee"/>
+                    <ns0:Property xmlns:ns0="http://tempuri.org/XMLSchema.xsd" nodeID="cd029979-b8e5-492a-bb18-ff42cae17ecc"/>
+                    <ns0:Property xmlns:ns0="http://tempuri.org/XMLSchema.xsd" nodeID="1bd4e74a-a7a8-4bfd-9bd2-a291a19b1324"/>
                 </AlphanumericalInformation>
             </SpecificationPerObjectType>
         </Specification>
     </Loin>
-    <Object nodeID="3b7802f6-b9a2-4062-ab23-69fa92c4984f">
-        <ns0:Name xmlns:ns0="http://tempuri.org/XMLSchema.xsd">Wing Wall</ns0:Name>
+    <Object nodeID="ca4c1d79-fccf-4d44-bce8-88db884eb8ee" date="2024-06-14T10:17:03">
+        <ns0:Name xmlns:ns0="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Wing Wall</ns0:Name>
+        <ns0:Name xmlns:ns0="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="de">Flügelmauer</ns0:Name>
     </Object>
-    <Unit nodeID="ebdfe50c-474a-482e-9bd6-db93bcaac3d1">
-        <ns0:Name xmlns:ns0="http://tempuri.org/XMLSchema.xsd">Centimeter</ns0:Name>
-        <ns0:Definition xmlns:ns0="http://tempuri.org/XMLSchema.xsd">Centimeter according to ISO 80000</ns0:Definition>
+    <Unit nodeID="f4b89165-3682-4018-9d5d-1ae76dbba9e6" date="2024-06-14T10:17:03">
+        <ns0:Name xmlns:ns0="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Centimeter</ns0:Name>
+        <ns0:Definition xmlns:ns0="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Centimeter according to ISO 80000</ns0:Definition>
+        <ns0:Symbol xmlns:ns0="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">cm</ns0:Symbol>
         <ns0:Scale xmlns:ns0="http://tempuri.org/XMLSchema.xsd">LINEAR</ns0:Scale>
         <ns0:Base xmlns:ns0="http://tempuri.org/XMLSchema.xsd">TEN</ns0:Base>
         <ns0:Coefficient xmlns:ns0="http://tempuri.org/XMLSchema.xsd">100</ns0:Coefficient>
         <ns0:Offset xmlns:ns0="http://tempuri.org/XMLSchema.xsd">0</ns0:Offset>
     </Unit>
-    <Property nodeID="8ef0be47-929f-428a-9016-ec1e1f1f7616">
-        <ns0:Name xmlns:ns0="http://tempuri.org/XMLSchema.xsd">width</ns0:Name>
-        <ns0:DataType xmlns:ns0="http://tempuri.org/XMLSchema.xsd">REAL</ns0:DataType>
-        <ns0:Unit xmlns:ns0="http://tempuri.org/XMLSchema.xsd" nodeID="ebdfe50c-474a-482e-9bd6-db93bcaac3d1"/>
+    <Property nodeID="cd029979-b8e5-492a-bb18-ff42cae17ecc" date="2024-06-14T10:17:03">
+        <ns0:Name xmlns:ns0="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Width</ns0:Name>
+        <ns0:DataType xmlns:ns0="http://tempuri.org/XMLSchema.xsd" name="REAL"/>
+        <ns0:Unit xmlns:ns0="http://tempuri.org/XMLSchema.xsd" nodeID="f4b89165-3682-4018-9d5d-1ae76dbba9e6"/>
     </Property>
-    <Property nodeID="c4a14d69-1ad7-4e66-bacc-7985e21493ba">
-        <ns0:Name xmlns:ns0="http://tempuri.org/XMLSchema.xsd">length</ns0:Name>
-        <ns0:DataType xmlns:ns0="http://tempuri.org/XMLSchema.xsd">REAL</ns0:DataType>
-        <ns0:Unit xmlns:ns0="http://tempuri.org/XMLSchema.xsd" nodeID="ebdfe50c-474a-482e-9bd6-db93bcaac3d1"/>
+    <Property nodeID="1bd4e74a-a7a8-4bfd-9bd2-a291a19b1324" date="2024-06-14T10:17:03">
+        <ns0:Name xmlns:ns0="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Length</ns0:Name>
+        <ns0:DataType xmlns:ns0="http://tempuri.org/XMLSchema.xsd" name="REAL"/>
+        <ns0:Unit xmlns:ns0="http://tempuri.org/XMLSchema.xsd" nodeID="f4b89165-3682-4018-9d5d-1ae76dbba9e6"/>
     </Property>
 </Container>


### PR DESCRIPTION
- Include date into constructors for types that require it, as it is not optional anymore (ObjectType, UnitType, PropertyType, DataTemplateType)
- Remove explicit setting of UUIDs as they are created automatically
- Names of the different types are lists of MultilingualTextType. Change code to append those instances to the list instead of setting the value to the string.
- Include german translation of the Object name for testing
- Use the correct enums for setting ScaleType etc. instead of assigning the string values
- Complete definition of centimeter unit
- Explicit imports instead of `*`
- Formatting