### PR TITLE
Update python code for schema rework

### DIFF
--- a/src/python/20240915_instance.py
+++ b/src/python/20240915_instance.py
@@ -1,0 +1,160 @@
+from xsdata.formats.dataclass.serializers import XmlSerializer
+from xsdata.formats.dataclass.serializers.config import SerializerConfig
+
+from loin.iso_7817_3 import (
+    AppearanceEnum,
+    DetailEnum,
+    DimensionalityEnum,
+    GeometricalInformation,
+    LevelOfInformationNeed,
+    LocationEnum,
+    ParametricBehaviourEnum,
+    RequiredDocument,
+    Specification,
+    SpecificationPerObjectType,
+    ObjectType,
+    Prerequisites,
+    Documentation,
+)
+from loin.iso_23887 import (
+    DatatypeType,
+    DatatypeTypeName,
+    GroupOfPropertiesType,
+    MultilingualTextType,
+    PhysicalQuantityType,
+    PropertyType,
+    ReferenceType,
+    UnitType,
+    DimensionType,
+)
+
+
+loin = LevelOfInformationNeed()
+
+# first, fill the information content with what we need
+
+real_type = DatatypeType()
+real_type.name = DatatypeTypeName.REAL
+real_type.min_inclusive = DatatypeType.MinInclusive(value=0.0)
+
+# references to external definitions 
+centimeter_unit_external_ref = ReferenceType(
+    resource="https://datadictionary2.org/cm")
+length_quantity_external_ref = ReferenceType(
+    resource="https://datadictionary3.org/length")
+
+length_dimension = DimensionType()
+length_dimension.name.append(MultilingualTextType("Length", "en"))
+length_dimension.name.append(MultilingualTextType("Länge", "de"))
+length_dimension.dimension_exponent_for_length = 1
+loin.information_content.dimension.append(length_dimension)
+length_dimension_reference = ReferenceType(node_id=length_dimension.node_id)
+
+centimeter_unit = UnitType()
+centimeter_unit.name.append(MultilingualTextType("Centimeter", "en"))
+centimeter_unit.name.append(MultilingualTextType("Zentimeter", "de"))
+centimeter_unit.definition.append(MultilingualTextType(
+    "Centimeter according to ISO 80000", "en"))
+centimeter_unit.dimension = length_dimension_reference
+loin.information_content.unit.append(centimeter_unit)
+centimeter_unit_ref = ReferenceType(node_id=centimeter_unit.node_id)
+
+length_quantity = PhysicalQuantityType()
+length_quantity.name.append(MultilingualTextType("Length", "en"))
+length_quantity.name.append(MultilingualTextType("Länge", "de"))
+length_quantity.definition.append(MultilingualTextType(
+    "Definition of Length physical quantity.", "en"))
+length_quantity.dimensions = length_dimension_reference
+loin.information_content.physical_quantity.append(length_quantity)
+length_quantity_ref = ReferenceType(node_id=length_quantity.node_id)
+
+wingwall = ObjectType()
+wingwall.name.append(MultilingualTextType("Wing Wall", "en"))
+wingwall.name.append(MultilingualTextType("Flügelmauer", "de"))
+wingwall.definition.append(MultilingualTextType(
+    "The lateral wall of a bridge abutment.", "en"))
+loin.information_content.object_type.append(wingwall)
+wingwall_ref = ReferenceType(node_id=wingwall.node_id)
+
+length = PropertyType()
+length.name.append(MultilingualTextType("Length", "en"))
+length.name.append(MultilingualTextType("Länge", "de"))
+length.definition.append(MultilingualTextType(
+    "Length according to ISO XXX-YYYY.", "en"))
+length.data_type = real_type
+length.unit.append(centimeter_unit_external_ref)
+length.physical_quantity = length_quantity_external_ref
+loin.information_content.property.append(length)
+length_ref = ReferenceType(node_id=length.node_id)
+
+width = PropertyType()
+width.name.append(MultilingualTextType("Width", "en"))
+width.name.append(MultilingualTextType("Breite", "de"))
+width.definition.append(MultilingualTextType(
+    "Width according to ISO XXX-YYYY.", "en"))
+width.data_type = real_type
+width.unit.append(centimeter_unit_ref)
+width.physical_quantity = length_quantity_ref
+loin.information_content.property.append(width)
+width_ref = ReferenceType(node_id=width.node_id)
+
+dimensions = GroupOfPropertiesType()
+dimensions.name.append(MultilingualTextType("Dimensions", "en"))
+dimensions.name.append(MultilingualTextType("Abmessungen", "de"))
+dimensions.definition.append(MultilingualTextType(
+    "Definition of Dimensions group of properties.", "en"))
+dimensions.property.append(length_ref)
+dimensions.property.append(width_ref)
+loin.information_content.set_of_properties.append(dimensions)
+dimensions_ref = ReferenceType(node_id=dimensions.node_id)
+
+
+# generate the specification using the parts we defined before
+specification = Specification()
+specification.name = "Bridge Handover to Client"
+specification.description = "Defines the requirements for bridge models when handed over to the client."
+loin.specification.append(specification)
+
+prerequisities = Prerequisites(purpose="Operation and Maintenance",
+                               information_delivery_milestone="Handover", sending_actor="Contractor",
+                               receiving_actor="Client")
+specification.prerequisites = prerequisities
+
+spec_per_object_type = SpecificationPerObjectType(
+    about="http://www.company.org/cum/sonoras")
+spec_per_object_type.name.append(
+    MultilingualTextType("Specification for Wing Wall", "en"))
+spec_per_object_type.definition.append(MultilingualTextType(
+    "The lateral wall of a bridge abutment.", "en"))
+spec_per_object_type.reference_document.append(ReferenceType(
+    resource="https://identifier.buildingsmart.org/uri/nbs/uniclass2015/1/class/Ss_20_50_10_95"))
+
+spec_per_object_type.object_value.append(wingwall_ref)
+spec_per_object_type.set_of_properties.append(dimensions_ref)
+
+required_document = RequiredDocument(
+    type_value="Technical Drawing", purpose="Archive", content="Horizontal Projection")
+doc = Documentation()
+doc.required_document.append(required_document)
+spec_per_object_type.documentation = doc
+
+geom_info = GeometricalInformation(detail=DetailEnum.L4, dimensionality=DimensionalityEnum.D0, location=LocationEnum.RELATIVE,
+                                   appearance=AppearanceEnum.TEXTURES, parametric_behaviour=ParametricBehaviourEnum.CONSTRUCTIVE_GEOMETRY)
+spec_per_object_type.geometrical_information = geom_info
+specification.specification_per_object_type.append(spec_per_object_type)
+
+
+# Create a SerializerConfig with custom settings
+serializer_config = SerializerConfig(
+    # Enable pretty-printing (adds line breaks and indentation)
+    pretty_print=True,
+    pretty_print_indent="    "  # Indentation using 4 spaces (adjust as needed)
+)
+
+# Serialize the object into an XML instance file
+serializer = XmlSerializer(config=serializer_config)
+xml_instance = serializer.render(loin)
+
+# Write the XML instance to a file
+with open("20240915_instance.xml", "w") as f:
+    f.write(xml_instance)

--- a/src/python/20240915_instance.xml
+++ b/src/python/20240915_instance.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ns0:LevelOfInformationNeed xmlns:ns0="https://iso.org/2022/LOIN">
+    <Specification nodeID="69d5d312-5e62-438f-93df-20b0c229d97c" name="Bridge Handover to Client">
+        <Description>Defines the requirements for bridge models when handed over to the client.</Description>
+        <Prerequisites purpose="Operation and Maintenance" informationDeliveryMilestone="Handover" sendingActor="Contractor" receivingActor="Client"/>
+        <SpecificationPerObjectType date="2024-09-16T18:09:08.940848" about="http://www.company.org/cum/sonoras" nodeID="5cf01918-1476-4c44-ab0c-c08b872aea6f">
+            <ns1:Name xmlns:ns1="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Specification for Wing Wall</ns1:Name>
+            <ns1:Definition xmlns:ns1="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">The lateral wall of a bridge abutment.</ns1:Definition>
+            <ns1:ReferenceDocument xmlns:ns1="http://tempuri.org/XMLSchema.xsd" resource="https://identifier.buildingsmart.org/uri/nbs/uniclass2015/1/class/Ss_20_50_10_95"/>
+            <ns1:Object xmlns:ns1="http://tempuri.org/XMLSchema.xsd" nodeID="3f6045db-0af7-4f46-b446-70c78827b937"/>
+            <ns1:SetOfProperties xmlns:ns1="http://tempuri.org/XMLSchema.xsd" nodeID="082c7078-139e-4e04-8a63-875a5ba7d8a2"/>
+            <Documentation>
+                <RequiredDocument type="Technical Drawing" purpose="Archive" content="Horizontal Projection"/>
+            </Documentation>
+            <GeometricalInformation>
+                <Detail>L4</Detail>
+                <Dimensionality>D0</Dimensionality>
+                <Location>Relative</Location>
+                <Appearance>Textures</Appearance>
+                <ParametricBehaviour>ConstructiveGeometry</ParametricBehaviour>
+            </GeometricalInformation>
+        </SpecificationPerObjectType>
+    </Specification>
+    <InformationContent>
+        <ns1:Object xmlns:ns1="pdt" date="2024-09-16T18:09:08.940799" nodeID="3f6045db-0af7-4f46-b446-70c78827b937">
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Wing Wall</ns2:Name>
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="de">Flügelmauer</ns2:Name>
+            <ns2:Definition xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">The lateral wall of a bridge abutment.</ns2:Definition>
+        </ns1:Object>
+        <ns1:Property xmlns:ns1="pdt" date="2024-09-16T18:09:08.940809" nodeID="2b07e5a2-6045-4c57-b1ea-59f1673ea0cb">
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Length</ns2:Name>
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="de">Länge</ns2:Name>
+            <ns2:Definition xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Length according to ISO XXX-YYYY.</ns2:Definition>
+            <ns2:DataType xmlns:ns2="http://tempuri.org/XMLSchema.xsd" name="REAL">
+                <ns2:MinInclusive value="0.0"/>
+            </ns2:DataType>
+            <ns2:Unit xmlns:ns2="http://tempuri.org/XMLSchema.xsd" resource="https://datadictionary2.org/cm"/>
+            <ns2:PhysicalQuantity xmlns:ns2="http://tempuri.org/XMLSchema.xsd" resource="https://datadictionary3.org/length"/>
+        </ns1:Property>
+        <ns1:Property xmlns:ns1="pdt" date="2024-09-16T18:09:08.940820" nodeID="f2b38e00-a9cc-4532-aa88-129886dc738a">
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Width</ns2:Name>
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="de">Breite</ns2:Name>
+            <ns2:Definition xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Width according to ISO XXX-YYYY.</ns2:Definition>
+            <ns2:DataType xmlns:ns2="http://tempuri.org/XMLSchema.xsd" name="REAL">
+                <ns2:MinInclusive value="0.0"/>
+            </ns2:DataType>
+            <ns2:Unit xmlns:ns2="http://tempuri.org/XMLSchema.xsd" nodeID="b9b63919-c4bd-40b6-bbdd-04aad4ed75ba"/>
+            <ns2:PhysicalQuantity xmlns:ns2="http://tempuri.org/XMLSchema.xsd" nodeID="1e6027dd-beb4-4956-bab4-d6a26164c005"/>
+        </ns1:Property>
+        <ns1:PhysicalQuantity xmlns:ns1="pdt" date="2024-09-16T18:09:08.940786" nodeID="1e6027dd-beb4-4956-bab4-d6a26164c005">
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Length</ns2:Name>
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="de">Länge</ns2:Name>
+            <ns2:Definition xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Definition of Length physical quantity.</ns2:Definition>
+            <ns2:Dimensions xmlns:ns2="http://tempuri.org/XMLSchema.xsd" nodeID="cd9f7d48-a247-4601-9141-cbb5e6f2f19e"/>
+        </ns1:PhysicalQuantity>
+        <ns1:SetOfProperties xmlns:ns1="pdt" date="2024-09-16T18:09:08.940830" nodeID="082c7078-139e-4e04-8a63-875a5ba7d8a2">
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Dimensions</ns2:Name>
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="de">Abmessungen</ns2:Name>
+            <ns2:Definition xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Definition of Dimensions group of properties.</ns2:Definition>
+            <ns2:Property xmlns:ns2="http://tempuri.org/XMLSchema.xsd" nodeID="2b07e5a2-6045-4c57-b1ea-59f1673ea0cb"/>
+            <ns2:Property xmlns:ns2="http://tempuri.org/XMLSchema.xsd" nodeID="f2b38e00-a9cc-4532-aa88-129886dc738a"/>
+        </ns1:SetOfProperties>
+        <ns1:Dimension xmlns:ns1="pdt" date="2024-09-16T18:09:08.940735" nodeID="cd9f7d48-a247-4601-9141-cbb5e6f2f19e">
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Length</ns2:Name>
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="de">Länge</ns2:Name>
+            <ns2:DimensionExponentForLength xmlns:ns2="http://tempuri.org/XMLSchema.xsd">1</ns2:DimensionExponentForLength>
+        </ns1:Dimension>
+        <ns1:Unit xmlns:ns1="pdt" date="2024-09-16T18:09:08.940766" nodeID="b9b63919-c4bd-40b6-bbdd-04aad4ed75ba">
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Centimeter</ns2:Name>
+            <ns2:Name xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="de">Zentimeter</ns2:Name>
+            <ns2:Definition xmlns:ns2="http://tempuri.org/XMLSchema.xsd" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">Centimeter according to ISO 80000</ns2:Definition>
+            <ns2:Dimension xmlns:ns2="http://tempuri.org/XMLSchema.xsd" nodeID="cd9f7d48-a247-4601-9141-cbb5e6f2f19e"/>
+        </ns1:Unit>
+    </InformationContent>
+</ns0:LevelOfInformationNeed>

--- a/src/python/loin/__init__.py
+++ b/src/python/loin/__init__.py
@@ -1,9 +1,10 @@
-from loin.en_17412_3 import (
+from loin.iso_7817_3 import (
     AppearanceEnum,
     DetailEnum,
     DimensionalityEnum,
     Documentation,
     GeometricalInformation,
+    InformationContent,
     LevelOfInformationNeed,
     LocationEnum,
     ParametricBehaviourEnum,
@@ -39,6 +40,7 @@ __all__ = [
     "DimensionalityEnum",
     "Documentation",
     "GeometricalInformation",
+    "InformationContent",
     "LevelOfInformationNeed",
     "LocationEnum",
     "ParametricBehaviourEnum",

--- a/src/python/loin/iso_23887.py
+++ b/src/python/loin/iso_23887.py
@@ -113,6 +113,7 @@ class ConceptType:
         name = "conceptType"
 
     date: XmlDateTime = field(
+        default_factory=XmlDateTime.now,
         metadata={
             "type": "Attribute",
             "required": True,

--- a/src/python/loin/iso_7817_3.py
+++ b/src/python/loin/iso_7817_3.py
@@ -1,0 +1,372 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional
+from loin.iso_23887 import (
+    DataTemplateType,
+    ObjectType,
+    PropertyType,
+    PhysicalQuantityType,
+    GroupOfPropertiesType,
+    ReferenceDocumentType,
+    DimensionType,
+    UnitType
+)
+from loin.utils import new_uuid
+
+__NAMESPACE__ = "https://iso.org/2022/LOIN"
+
+
+class AppearanceEnum(Enum):
+    NO_COLOR = "NoColor"
+    SINGLE_COLOR = "SingleColor"
+    MATERIAL_COLOR = "MaterialColor"
+    TEXTURES = "Textures"
+
+
+class DetailEnum(Enum):
+    L1 = "L1"
+    L2 = "L2"
+    L3 = "L3"
+    L4 = "L4"
+    L5 = "L5"
+
+
+class DimensionalityEnum(Enum):
+    D0 = "D0"
+    D1 = "D1"
+    D2 = "D2"
+    D3 = "D3"
+
+
+class LocationEnum(Enum):
+    ABSOLUTE = "Absolute"
+    RELATIVE = "Relative"
+
+
+class ParametricBehaviourEnum(Enum):
+    EXPLICIT_GEOMETRY = "ExplicitGeometry"
+    CONSTRUCTIVE_GEOMETRY = "ConstructiveGeometry"
+    PARAMETRIC_GEOMETRY = "ParametricGeometry"
+
+
+@dataclass
+class Prerequisites:
+    node_id: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "nodeID",
+            "type": "Attribute",
+            "pattern": r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
+        }
+    )
+    purpose: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+    information_delivery_milestone: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "informationDeliveryMilestone",
+            "type": "Attribute",
+        }
+    )
+    sending_actor: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "sendingActor",
+            "type": "Attribute",
+        }
+    )
+    receiving_actor: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "receivingActor",
+            "type": "Attribute",
+        }
+    )
+
+
+@dataclass
+class RequiredDocument:
+    type_value: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "type",
+            "type": "Attribute",
+        }
+    )
+    purpose: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+    content: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+    node_id: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "nodeID",
+            "type": "Attribute",
+            "pattern": r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
+        }
+    )
+
+
+@dataclass
+class Documentation:
+    required_document: List[RequiredDocument] = field(
+        default_factory=list,
+        metadata={
+            "name": "RequiredDocument",
+            "type": "Element",
+            "namespace": "",
+        }
+    )
+    node_id: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "nodeID",
+            "type": "Attribute",
+            "pattern": r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
+        }
+    )
+
+
+@dataclass
+class GeometricalInformation:
+    detail: Optional[DetailEnum] = field(
+        default=None,
+        metadata={
+            "name": "Detail",
+            "type": "Element",
+            "namespace": "",
+        }
+    )
+    dimensionality: Optional[DimensionalityEnum] = field(
+        default=None,
+        metadata={
+            "name": "Dimensionality",
+            "type": "Element",
+            "namespace": "",
+        }
+    )
+    location: Optional[LocationEnum] = field(
+        default=None,
+        metadata={
+            "name": "Location",
+            "type": "Element",
+            "namespace": "",
+        }
+    )
+    appearance: Optional[AppearanceEnum] = field(
+        default=None,
+        metadata={
+            "name": "Appearance",
+            "type": "Element",
+            "namespace": "",
+        }
+    )
+    parametric_behaviour: Optional[ParametricBehaviourEnum] = field(
+        default=None,
+        metadata={
+            "name": "ParametricBehaviour",
+            "type": "Element",
+            "namespace": "",
+        }
+    )
+    node_id: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "nodeID",
+            "type": "Attribute",
+            "pattern": r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
+        }
+    )
+
+
+@dataclass
+class SpecificationPerObjectType(DataTemplateType):
+    documentation: Optional[Documentation] = field(
+        default=None,
+        metadata={
+            "name": "Documentation",
+            "type": "Element",
+            "namespace": "",
+        }
+    )
+    geometrical_information: Optional[GeometricalInformation] = field(
+        default=None,
+        metadata={
+            "name": "GeometricalInformation",
+            "type": "Element",
+            "namespace": "",
+        }
+    )
+
+
+@dataclass
+class Specification:
+    description: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "Description",
+            "type": "Element",
+            "namespace": "",
+        }
+    )
+    prerequisites: Optional[Prerequisites] = field(
+        default=None,
+        metadata={
+            "name": "Prerequisites",
+            "type": "Element",
+            "namespace": "",
+        }
+    )
+    specification_per_object_type: List[SpecificationPerObjectType] = field(
+        default_factory=list,
+        metadata={
+            "name": "SpecificationPerObjectType",
+            "type": "Element",
+            "namespace": "",
+            "nillable": True,
+        }
+    )
+    node_id: Optional[str] = field(
+        default_factory=new_uuid,
+        metadata={
+            "name": "nodeID",
+            "type": "Attribute",
+            "pattern": r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
+        }
+    )
+    name: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+
+
+@dataclass
+class InformationContent:
+    object_type: List[ObjectType] = field(
+        default_factory=list,
+        metadata={
+            "name": "Object",
+            "type": "Element",
+            "namespace": "pdt",
+        }
+    )
+    property: List[PropertyType] = field(
+        default_factory=list,
+        metadata={
+            "name": "Property",
+            "type": "Element",
+            "namespace": "pdt",
+        }
+    )
+    physical_quantity: List[PhysicalQuantityType] = field(
+        default_factory=list,
+        metadata={
+            "name": "PhysicalQuantity",
+            "type": "Element",
+            "namespace": "pdt",
+        }
+    )
+    set_of_properties: List[GroupOfPropertiesType] = field(
+        default_factory=list,
+        metadata={
+            "name": "SetOfProperties",
+            "type": "Element",
+            "namespace": "pdt",
+        }
+    )
+    purpose: List[GroupOfPropertiesType] = field(
+        default_factory=list,
+        metadata={
+            "name": "Purpose",
+            "type": "Element",
+            "namespace": "pdt",
+        }
+    )
+    intended_use: List[GroupOfPropertiesType] = field(
+        default_factory=list,
+        metadata={
+            "name": "IntendedUse",
+            "type": "Element",
+            "namespace": "pdt",
+        }
+    )
+    user_defined: List[GroupOfPropertiesType] = field(
+        default_factory=list,
+        metadata={
+            "name": "UserDefined",
+            "type": "Element",
+            "namespace": "pdt",
+        }
+    )
+    reference_document: List[ReferenceDocumentType] = field(
+        default_factory=list,
+        metadata={
+            "name": "ReferenceDocument",
+            "type": "Element",
+            "namespace": "pdt",
+        }
+    )
+    dimension: List[DimensionType] = field(
+        default_factory=list,
+        metadata={
+            "name": "Dimension",
+            "type": "Element",
+            "namespace": "pdt",
+        }
+    )
+    unit: List[UnitType] = field(
+        default_factory=list,
+        metadata={
+            "name": "Unit",
+            "type": "Element",
+            "namespace": "pdt",
+        }
+    )
+    node_id: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "nodeID",
+            "type": "Attribute",
+            "pattern": r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
+        }
+    )
+
+
+@dataclass
+class LevelOfInformationNeed:
+    """
+    Level of Information Need as defined by EN 17412.
+    """
+    class Meta:
+        namespace = "https://iso.org/2022/LOIN"
+
+    specification: List[Specification] = field(
+        default_factory=list,
+        metadata={
+            "name": "Specification",
+            "type": "Element",
+            "namespace": "",
+        }
+    )
+    information_content: InformationContent = field(
+        default_factory=InformationContent,
+        metadata={
+            "name": "InformationContent",
+            "type": "Element",
+            "namespace": "",
+        }
+    )


### PR DESCRIPTION
This commit updates the python implementation of the LOIN schema to the latest version, where the correspondence to the PDT schema is in the `SpecificationPerObjectType`. The code has been changed to reflect that the norm is now ISO 7817-3.
The only deviation from the XSD is that the `AlphanumericalInformation` type has been renamed to `InformationContent` to distinguish from the old terminology. This can be adjusted!
Also, the `20240915_instance.py` file uses the new implementation to reproduce the `ISO-7817-3_instance.xml` example. The resulting XML is a bit more verbose, but this is due to me not looking into the namespace functionality of the `xsdata` module, but else they are matching. The code to reproduce the example is probably hard to read for outsiders, but as a proof of concept this should be sufficient.